### PR TITLE
Allowing users to pass learning rate schedulers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 0.3.2
+:Version: 0.4.0
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -1,5 +1,6 @@
 import numpy as np
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow_probability import (bijectors as tfb, distributions as tfd)
 from margarine.processing import _forward_transform, _inverse_transform
 import pickle
@@ -115,8 +116,11 @@ class MAF(object):
 
         if type(self.number_networks) is not int:
             raise TypeError("'number_networks' must be an integer.")
-        if type(self.learning_rate) not in [int, float]:
-            raise TypeError("'learning_rate', must be a float.")
+        if not isinstance(self.learning_rate,
+                          (int, float,
+                           keras.optimizers.schedules.LearningRateSchedule)):
+            raise TypeError("'learning_rate', " +
+                            "must be an integer, float or keras scheduler.")
         if type(self.hidden_layers) is not list:
             raise TypeError("'hidden_layers' must be a list of integers.")
         else:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='0.3.2',
+    version='0.4.0',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',


### PR DESCRIPTION
Solving issue #14 but changing the conditional check on the `learning_rate` kwarg to

```python
if not isinstance(self.learning_rate,
                          (int, float,
                           keras.optimizers.schedules.LearningRateSchedule)):
            raise TypeError("'learning_rate', " +
                            "must be an integer, float or keras scheduler.")
```