### PR TITLE
Reducing max cluster size and adding a catch for small clusters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 0.5.0
+:Version: 0.5.1
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -229,6 +229,7 @@ class MAF(object):
 
         # count the number of times a cluster label appears in cluster_labels
         self.cluster_count = np.bincount(self.cluster_labels)
+        print(self.cluster_count)
         # While loop to make sure clusters are not too small
         while self.cluster_count.min() < 100:
             warnings.warn("One or more clusters are too small " +
@@ -242,10 +243,10 @@ class MAF(object):
             if self.cluster_number == 2:
                 # break if two clusters
                 warnings.warn("The number of clusters is 2. This is the " +
-                                "minimum number of clusters that can be used. " +
-                                "Some clusters may be too small and the " +
-                                "train/test split may fail." +
-                                "Try running without clusting. ")
+                            "minimum number of clusters that can be used. " +
+                            "Some clusters may be too small and the " +
+                            "train/test split may fail." +
+                            "Try running without clusting. ")
                 break
 
         self.n, split_theta, self.new_theta_max = [], [], []

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -241,6 +241,11 @@ class MAF(object):
             self.cluster_count = np.bincount(self.cluster_labels)
             if self.cluster_number == 2:
                 # break if two clusters
+                warnings.warn("The number of clusters is 2. This is the " +
+                                "minimum number of clusters that can be used. " +
+                                "Some clusters may be too small and the " +
+                                "train/test split may fail." +
+                                "Try running without clusting. ")
                 break
 
         self.n, split_theta, self.new_theta_max = [], [], []

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -229,7 +229,6 @@ class MAF(object):
 
         # count the number of times a cluster label appears in cluster_labels
         self.cluster_count = np.bincount(self.cluster_labels)
-        print(self.cluster_count)
         # While loop to make sure clusters are not too small
         while self.cluster_count.min() < 100:
             warnings.warn("One or more clusters are too small " +

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -226,7 +226,10 @@ class MAF(object):
                             "require more clusters, please specify the " +
                             "'cluster_number' kwarg. margarine will continue "+
                             "with 20 clusters.")
-
+        
+        if np.array(list(self.cluster_labels)).dtype == 'float':
+            # convert cluster labels to integers
+            self.cluster_labels = self.cluster_labels.astype(int)
         # count the number of times a cluster label appears in cluster_labels
         self.cluster_count = np.bincount(self.cluster_labels)
         # While loop to make sure clusters are not too small

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -207,17 +207,41 @@ class MAF(object):
 
         if self.cluster_number is None:
             from sklearn.metrics import silhouette_score
-            ks = np.arange(2, 101)
+            ks = np.arange(2, 21)
             losses = []
             for k in ks:
                 kmeans = KMeans(k, random_state=0)
                 labels = kmeans.fit(self.theta).predict(self.theta)
                 losses.append(-silhouette_score(self.theta, labels))
             losses = np.array(losses)
-            self.cluster_number = ks[np.where(losses == losses.min())[0][0]]
+            minimum_index = np.argmin(losses)
+            self.cluster_number = ks[minimum_index]
 
             kmeans = KMeans(self.cluster_number, random_state=0)
             self.cluster_labels = kmeans.fit(self.theta).predict(self.theta)
+        
+        if self.cluster_number == 20:
+            warnings.warn("The number of clusters is 20. This is the maximum "+
+                            "number of clusters that can be used. If you " +
+                            "require more clusters, please specify the " +
+                            "'cluster_number' kwarg. margarine will continue "+
+                            "with 20 clusters.")
+
+        # count the number of times a cluster label appears in cluster_labels
+        self.cluster_count = np.bincount(self.cluster_labels)
+        # While loop to make sure clusters are not too small
+        while self.cluster_count.min() < 100:
+            warnings.warn("One or more clusters are too small " +
+                          "(n_cluster < 100). " +
+                          "Reducing the number of clusters by 1.")
+            minimum_index -= 1
+            self.cluster_number = ks[minimum_index]
+            kmeans = KMeans(self.cluster_number, random_state=0)
+            self.cluster_labels = kmeans.fit(self.theta).predict(self.theta)
+            self.cluster_count = np.bincount(self.cluster_labels)
+            if self.cluster_number == 2:
+                # break if two clusters
+                break
 
         self.n, split_theta, self.new_theta_max = [], [], []
         self.new_theta_min, split_sample_weights = [], []

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='0.5.0',
+    version='0.5.1',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -72,3 +72,13 @@ def test_maf_cluster_kwargs():
     bij = MAF(theta, weights, cluster_number=2, 
               cluster_labels=labels)
     assert_equal(bij.clustering, True)
+
+def test_cluster_size():
+    # testing the while loop for cluster size
+    def draw(ndims):
+        return np.random.multivariate_normal(
+                np.zeros(ndims), np.eye(ndims), ndims*10)
+
+    samples = draw(3)
+    flow = MAF(samples, np.ones(len(samples)), clustering=True)
+    return 0


### PR DESCRIPTION
Solving #23 and #21.

Reduced the maximum cluster number to 20 and added a warning if `cluster_number = 20` suggesting that the user should explore their data a bit more externally to `margarine`.

Added a catch that lowers the cluster number if any of the clusters are smaller than 100 samples. Prevents errors when we try to train/test split clusters with fewer than 5 samples and ensures that the test size for each cluster is somewhat reasonable (minimum 20 samples).