### PR TITLE
Anesthetic integration

### DIFF
--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -117,7 +117,6 @@ class MAF(object):
     """
 
     def __init__(self, theta, **kwargs):
-        self.sample_weights = kwargs.pop('weights', np.ones(len(theta)))
         self.number_networks = kwargs.pop('number_networks', 6)
         self.learning_rate = kwargs.pop('learning_rate', 1e-3)
         self.hidden_layers = kwargs.pop('hidden_layers', [50, 50])
@@ -131,7 +130,9 @@ class MAF(object):
                        'anesthetic.samples.MCMCSamples')):
             theta = theta['parameter_names'].values
             self.sample_weights = theta.get_weights()
-
+        else:
+            self.sample_weights = kwargs.pop('weights', np.ones(len(theta)))
+        
         if self.cluster_number is not None:
             if self.cluster_labels is None:
                 raise ValueError("'cluster_labels' should be provided if " +

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -24,10 +24,10 @@ class MAF(object):
             | The samples from the probability distribution that we require the
                 MAF to learn.
 
-        weights: **numpy array**
-            | The weights associated with the samples above.
-
     **kwargs:**
+
+        weights: **numpy array / default=np.ones(len(theta))**
+            | The weights associated with the samples above.
 
         number_networks: **int / default = 6**
             | The bijector is built by chaining a series of
@@ -116,7 +116,8 @@ class MAF(object):
 
     """
 
-    def __init__(self, theta, weights, **kwargs):
+    def __init__(self, theta, **kwargs):
+        self.sample_weights = kwargs.pop('weights', np.ones(len(theta)))
         self.number_networks = kwargs.pop('number_networks', 6)
         self.learning_rate = kwargs.pop('learning_rate', 1e-3)
         self.hidden_layers = kwargs.pop('hidden_layers', [50, 50])
@@ -136,8 +137,7 @@ class MAF(object):
         if self.cluster_labels is not None and self.cluster_number is not None:
             self.clustering = True
 
-        self.n = (np.sum(weights)**2)/(np.sum(weights**2))
-        self.sample_weights = weights
+        self.n = np.sum(self.sample_weights)**2/np.sum(self.sample_weights**2)
 
         theta_max = np.max(theta, axis=0)
         theta_min = np.min(theta, axis=0)

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -124,6 +124,13 @@ class MAF(object):
         self.clustering = kwargs.pop('clustering', False)
         self.cluster_labels = kwargs.pop('cluster_labels', None)
         self.cluster_number = kwargs.pop('cluster_number', None)
+        self.parameter_names = kwargs.pop('parameter_names', None)
+
+        if isinstance(theta, 
+                      ('anesthetic.samples.NestedSamples', 
+                       'anesthetic.samples.MCMCSamples')):
+            theta = theta['parameter_names'].values
+            self.sample_weights = theta.get_weights()
 
         if self.cluster_number is not None:
             if self.cluster_labels is None:


### PR DESCRIPTION
Attempting to somewhat integrate [`anesthetic`](https://github.com/handley-lab/anesthetic) into `margarine`.

Super simple stuff at the moment. Moved weights to an optional input, with a default of `np.ones(len(theta))` and then allowing the user to pass an `anesthetic.samples.MCMCSamples` or `anesthetic.samples.NestedSamples`  object for `theta`.

- [ ] Need to add tests
- [ ] Need to edit tutorials and docs
- [ ] Need to bump version number
- [ ] Need to run flake8

Should solve #22.