### PR TITLE
Tqdm and small compile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 0.5.1
+:Version: 0.6.0
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -10,6 +10,7 @@ import margarine
 from scipy.special import logsumexp
 from sklearn.model_selection import train_test_split
 
+import tqdm 
 
 class MAF(object):
 
@@ -367,7 +368,7 @@ class MAF(object):
         self.loss_history = []
         self.test_loss_history = []
         c = 0
-        for i in range(self.epochs):
+        for i in tqdm.tqdm(range(self.epochs)):
             loss = self._train_step(phi_train,
                                     weights_phi_train,
                                     self.loss_type, maf).numpy()
@@ -400,7 +401,8 @@ class MAF(object):
                               '. Minimum at epoch = ' + str(minimum_epoch))
                         return minimum_model
         return maf
-
+    
+    @tf.function(jit_compile=True)
     def _train_step(self, x, w, loss_type, maf):
 
         r"""

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -9,8 +9,8 @@ import warnings
 import margarine
 from scipy.special import logsumexp
 from sklearn.model_selection import train_test_split
-
 import tqdm 
+
 
 class MAF(object):
 
@@ -402,7 +402,7 @@ class MAF(object):
                         return minimum_model
         return maf
     
-    @tf.function(jit_compile=True)
+    #@tf.function(jit_compile=True)
     def _train_step(self, x, w, loss_type, maf):
 
         r"""
@@ -410,17 +410,17 @@ class MAF(object):
         adjust the weights and biases of the neural networks via the
         optimizer algorithm.
         """
-
+        
         with tf.GradientTape() as tape:
             if loss_type == 'sum':
                 loss = -tf.reduce_sum(w*maf.log_prob(x))
             elif loss_type == 'mean':
                 loss = -tf.reduce_mean(w*maf.log_prob(x))
-            gradients = tape.gradient(loss, maf.trainable_variables)
-            self.optimizer.apply_gradients(
-                zip(gradients,
-                    maf.trainable_variables))
-            return loss
+        gradients = tape.gradient(loss, maf.trainable_variables)
+        self.optimizer.apply_gradients(
+            zip(gradients,
+                maf.trainable_variables))
+        return loss
 
     def __call__(self, u):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tensorflow_probability
 scipy
 pandas
 scikit-learn
+tqdm

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='0.5.1',
+    version='0.6.0',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',


### PR DESCRIPTION
A small quality of life request in a progress bar for training. 

A second small ( but potentially breaking change?) in wrapping the train step in a jit wrapper. Naively gives a factor 2 improvement in run time on CPU and GPU as far as I can see, but may need more advanced checking on other hardware.

More broadly I tried putting the training on a GPU and saw little speed up, I started digging through the code and I think there are quite a lot of conversions to numpy and non-TF operations. So at the moment there isn't much gain from GPU usage here, but the JIT compilation still looks advantageous.