### PR TITLE
Some updates to improve speed of sampling

### DIFF
--- a/margarine/kde.py
+++ b/margarine/kde.py
@@ -97,7 +97,7 @@ class KDE(object):
         space and then generates a weighted KDE.
         """
 
-        phi = _forward_transform(self.theta, self.theta_min, self.theta_max)
+        phi = _forward_transform(self.theta, self.theta_min, self.theta_max).numpy()
         mask = np.isfinite(phi).all(axis=-1)
         phi = phi[mask, :]
         weights_phi = self.sample_weights[mask]
@@ -145,7 +145,7 @@ class KDE(object):
                     bracket=(mu[:, i].min()*2, mu[:, i].max()*2),
                     method='bisect').root
             transformed_samples.append(
-                _inverse_transform(y, self.theta_min, self.theta_max))
+                _inverse_transform(y, self.theta_min, self.theta_max).numpy())
         transformed_samples = np.array(transformed_samples)
         return transformed_samples
 
@@ -167,7 +167,7 @@ class KDE(object):
 
         """
         x = self.kde.resample(length).T
-        return _inverse_transform(x, self.theta_min, self.theta_max)
+        return _inverse_transform(x, self.theta_min, self.theta_max).numpy()
 
     def log_prob(self, params):
 
@@ -191,7 +191,7 @@ class KDE(object):
         maxs = self.theta_max.astype(np.float32)
 
         transformed_x = _forward_transform(
-            params, mins, maxs)
+            params, mins, maxs).numpy()
 
         transform_chain = tfb.Chain([
             tfb.Invert(tfb.NormalCDF()),

--- a/margarine/processing.py
+++ b/margarine/processing.py
@@ -1,4 +1,5 @@
 from tensorflow_probability import distributions as tfd
+import tensorflow as tf
 
 
 def _forward_transform(x, min=0, max=1):
@@ -24,8 +25,9 @@ def _forward_transform(x, min=0, max=1):
                 values...)
 
     """
-    x = tfd.Uniform(min, max).cdf(x).numpy()
-    x = tfd.Normal(0, 1).quantile(x).numpy()
+    x = tf.cast(x, tf.float32)
+    x = tfd.Uniform(min, max).cdf(x)
+    x = tfd.Normal(0, 1).quantile(x)
     return x
 
 
@@ -51,6 +53,9 @@ def _inverse_transform(x, min, max):
                 values...)
 
     """
-    x = tfd.Normal(0, 1).cdf(x).numpy()
-    x = tfd.Uniform(min, max).quantile(x).numpy()
+    x = tfd.Normal(0, 1).cdf(x)
+    print(min)
+    min = tf.cast(min, tf.float32)
+    max = tf.cast(max, tf.float32)
+    x = tfd.Uniform(min, max).quantile(x)
     return x

--- a/margarine/processing.py
+++ b/margarine/processing.py
@@ -26,6 +26,8 @@ def _forward_transform(x, min=0, max=1):
 
     """
     x = tf.cast(x, tf.float32)
+    min = tf.cast(min, tf.float32)
+    max = tf.cast(max, tf.float32)
     x = tfd.Uniform(min, max).cdf(x)
     x = tfd.Normal(0, 1).quantile(x)
     return x
@@ -54,7 +56,6 @@ def _inverse_transform(x, min, max):
 
     """
     x = tfd.Normal(0, 1).cdf(x)
-    print(min)
     min = tf.cast(min, tf.float32)
     max = tf.cast(max, tf.float32)
     x = tfd.Uniform(min, max).quantile(x)


### PR DESCRIPTION
Decorating the relevant functions inside a `MAF.__call__` with a @tf.function(jit_compile=True) decorator to speed up the sampling. Seen marginal improvements on some test examples.