### PR TITLE
MAF function rewrite, additional processing and seperated out clustering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 0.6.0
+:Version: 1.0.0
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -8,22 +8,23 @@ margarine.maf.MAF()
 ~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: margarine.maf.MAF()
-    :members: _train_step, train, __call__, sample, save, load
+    :members: gen_mades, train, _train_step, _test_step, _training, __call__, sample, log_prob, log_like, save, load
 
 margarine.kde.KDE()
 ~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: margarine.kde.KDE()
-    :members: generate_kde, __call__, sample, save, load
+    :members: generate_kde, __call__, sample, log_prob, log_like, save, load
 
-margarine.marginal_stats.maf_calculations()
+margarine.clustered.clusterMAF()
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: margarine.clustered.clusterMAF()
+    :members: train, __call__, sample, log_prob, log_like, save, load
+
+margarine.marginal_stats.calculate()
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automodule:: margarine.marginal_stats.maf_calculations
-    :members: _calc_logL, klDiv, bayesian_dimensionality
+.. automodule:: margarine.marginal_stats.calculate
+    :members: statistics
 
-margarine.marginal_stats.kde_calculations()
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: margarine.marginal_stats.kde_calculations
-    :members: _calc_logL, klDiv, bayesian_dimensionality

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -2,7 +2,7 @@ from scipy.special import logsumexp
 from sklearn.cluster import KMeans
 import margarine
 from tensorflow import keras
-from margarine.new_maf import MAF
+from margarine.maf import MAF
 import numpy as np
 import tensorflow as tf
 import warnings

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -77,6 +77,8 @@ class clusterMAF():
         theta_min = np.min(self.theta, axis=0)
         a = ((self.n-2)*theta_max-theta_min)/(self.n-3)
         b = ((self.n-2)*theta_min-theta_max)/(self.n-3)
+        self.theta_min  = b
+        self.theta_max = a
 
         if type(self.number_networks) is not int:
             raise TypeError("'number_networks' must be an integer.")

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -184,6 +184,37 @@ class clusterMAF():
         
     def train(self, epochs=100, early_stop=False, loss_type='sum'):
 
+        r"""
+        This function is called to train the clusterMAF once it has been
+        initialised. It calls the `train()` function for each flow.
+
+        .. code:: python
+
+            from margarine.clustered import clusterMAF
+
+            bij = clusterMAF(theta, weights)
+            bij.train()
+
+        **Kwargs:**
+
+            epochs: **int / default = 100**
+                | The number of iterations to train the neural networks for.
+
+            early_stop: **boolean / default = False**
+                | Determines whether or not to implement an early stopping
+                    algorithm or
+                    train for the set number of epochs. If set to True then the
+                    algorithm will stop training when test loss has not
+                    improved for 2% of the requested epochs. At this point
+                    margarine will roll back to the best model and return this
+                    to the user.
+            
+            loss_type: **string / default = 'sum'**
+                | Determines whether to use the sum or mean of the weighted
+                    log probabilities to calculate the loss function.
+
+        """
+
         for i in range(len(self.flow)):
             self.flow[i].train(epochs=epochs, early_stop=early_stop, 
                                loss_type=loss_type)

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -1,0 +1,255 @@
+from scipy.special import logsumexp
+from sklearn.cluster import KMeans
+import margarine
+from tensorflow import keras
+from margarine.new_maf import MAF
+import numpy as np
+import tensorflow as tf
+import warnings
+import pickle
+
+
+class clusterMAF():
+
+    def __init__(self, theta, weights, **kwargs):
+        self.number_networks = kwargs.pop('number_networks', 6)
+        self.learning_rate = kwargs.pop('learning_rate', 1e-3)
+        self.hidden_layers = kwargs.pop('hidden_layers', [50, 50])
+        self.cluster_labels = kwargs.pop('cluster_labels', None)
+        self.cluster_number = kwargs.pop('cluster_number', None)
+        self.theta = theta
+        self.weights = weights
+
+        if type(self.number_networks) is not int:
+            raise TypeError("'number_networks' must be an integer.")
+        if not isinstance(self.learning_rate,
+                          (int, float,
+                           keras.optimizers.schedules.LearningRateSchedule)):
+            raise TypeError("'learning_rate', " +
+                            "must be an integer, float or keras scheduler.")
+        if type(self.hidden_layers) is not list:
+            raise TypeError("'hidden_layers' must be a list of integers.")
+        else:
+            for i in range(len(self.hidden_layers)):
+                if type(self.hidden_layers[i]) is not int:
+                    raise TypeError(
+                        "One or more valus in 'hidden_layers'" +
+                        "is not an integer.")
+
+        mask = np.isfinite(theta).all(axis=-1)
+        self.theta = self.theta[mask]
+        self.weights = self.weights[mask]
+
+        if self.cluster_number is not None:
+            if self.cluster_labels is None:
+                raise ValueError("'cluster_labels' should be provided if " +
+                                 "'cluster_number' is specified.")
+        else:
+            if self.cluster_labels is not None:
+                raise ValueError("'cluster_number' should be provided if " +
+                                 "'cluster_labels' is specified.")
+        
+        if self.cluster_number is not None:
+            if self.cluster_number%1!=0:
+                raise TypeError("'cluster_number' must be a whole number.")
+        if self.cluster_labels is not None:
+            if not isinstance(self.cluster_labels, (np.ndarray, list)):
+                raise TypeError("'cluster_labels' must be an array " +
+                                "or a list.")
+
+        if self.cluster_number is None:
+            from sklearn.metrics import silhouette_score
+            ks = np.arange(2, 21)
+            losses = []
+            for k in ks:
+                kmeans = KMeans(k, random_state=0)
+                labels = kmeans.fit(self.theta).predict(self.theta)
+                losses.append(-silhouette_score(self.theta, labels))
+            losses = np.array(losses)
+            minimum_index = np.argmin(losses)
+            self.cluster_number = ks[minimum_index]
+
+            kmeans = KMeans(self.cluster_number, random_state=0)
+            self.cluster_labels = kmeans.fit(self.theta).predict(self.theta)
+        
+        if self.cluster_number == 20:
+            warnings.warn("The number of clusters is 20. This is the maximum "+
+                            "number of clusters that can be used. If you " +
+                            "require more clusters, please specify the " +
+                            "'cluster_number' kwarg. margarine will continue "+
+                            "with 20 clusters.")
+        
+        if np.array(list(self.cluster_labels)).dtype == 'float':
+            # convert cluster labels to integers
+            self.cluster_labels = self.cluster_labels.astype(int)
+        # count the number of times a cluster label appears in cluster_labels
+        self.cluster_count = np.bincount(self.cluster_labels)
+        # While loop to make sure clusters are not too small
+        while self.cluster_count.min() < 100:
+            warnings.warn("One or more clusters are too small " +
+                          "(n_cluster < 100). " +
+                          "Reducing the number of clusters by 1.")
+            minimum_index -= 1
+            self.cluster_number = ks[minimum_index]
+            kmeans = KMeans(self.cluster_number, random_state=0)
+            self.cluster_labels = kmeans.fit(self.theta).predict(self.theta)
+            self.cluster_count = np.bincount(self.cluster_labels)
+            if self.cluster_number == 2:
+                # break if two clusters
+                warnings.warn("The number of clusters is 2. This is the " +
+                            "minimum number of clusters that can be used. " +
+                            "Some clusters may be too small and the " +
+                            "train/test split may fail." +
+                            "Try running without clusting. ")
+                break
+        
+        split_theta = []
+        split_sample_weights = []
+        for i in range(self.cluster_number):
+            split_theta.append(self.theta[self.cluster_labels == i])
+            split_sample_weights.append(
+                self.weights[self.cluster_labels == i])
+        
+        self.split_theta = split_theta
+        self.split_sample_weights = split_sample_weights
+        
+        self.flow = []
+        for i in range(len(split_theta)):
+            # need to ba able to pass number networks etc here
+            self.flow.append(MAF(split_theta[i], split_sample_weights[i],
+                                 number_networks=self.number_networks,
+                                 learning_rate=self.learning_rate,
+                                 hidden_layers=self.hidden_layers))
+        
+    def train(self, epochs=100, early_stop=False, loss_type='sum'):
+
+        for i in range(len(self.flow)):
+            self.flow[i].train(epochs=epochs, early_stop=early_stop, 
+                               loss_type=loss_type)
+    
+    def log_prob(self, params):
+        
+        # currently working with numpy not tensorflow
+        # nan repalacement with 0 difficult in tensorflow
+        logprob = []
+        for flow in self.flow:
+            probs = flow.log_prob(params).numpy()
+            print(probs)
+            for j in range(len(probs)):
+                if np.isnan(probs[j]):
+                    probs[j] = np.log(1e-300)
+                logprob.append(probs)
+        logprob = np.array(logprob)
+        logprob = logsumexp(logprob, axis=0)
+
+        return logprob
+    
+    def log_like(self, params, logevidence, prior=None):
+        
+        if prior is None:
+            warnings.warn('Assuming prior is uniform!')
+
+            n = (np.sum(self.weights)**2)/(np.sum(self.weights**2))
+
+            theta_max = np.max(self.theta, axis=0)
+            theta_min = np.min(self.theta, axis=0)
+            a = ((n-2)*theta_max-theta_min)/(n-3)
+            b = ((n-2)*theta_min-theta_max)/(n-3)
+            prior_logprob = np.log(
+                np.prod([1/(a - b)
+                         for i in range(len(b))]))
+        else:
+            prior_logprob = prior.log_prob(params).numpy()
+
+        posterior_logprob = self.log_prob(params)
+
+        loglike = posterior_logprob + prior_logprob - logevidence
+
+        return loglike
+    
+    @tf.function(jit_compile=True)
+    def __call__(self, u):
+
+        len_thetas = [len(self.split_theta[i]) 
+                      for i in range(len(self.split_theta))]
+        probabilities = [len_thetas[i]/np.sum(len_thetas)
+                            for i in range(len(self.split_theta))]
+        options = np.arange(0, self.cluster_number)
+        choice = np.random.choice(options,
+                                    p=probabilities, size=len(u))
+
+        totals = [len(choice[choice == options[i]])
+                    for i in range(len(options))]
+        totals = np.hstack([0, np.cumsum(totals)])
+
+        values = []
+        for i in range(len(options)):
+            x = self.flow[i](u[totals[i]:totals[i+1]])
+            values.append(x)
+
+        x = tf.concat(values, axis=0)
+        return x
+    
+    def sample(self, length=1000):
+        u = np.random.uniform(size=(length, self.theta.shape[-1]))
+        return self(u)
+    
+    def save(self, filename):
+        nn_weights = {}
+        for i in range(self.cluster_number):
+            made = self.flow[i].mades
+            w = [m.get_weights() for m in made]
+            nn_weights[i] = w
+
+        with open(filename, 'wb') as f:
+            pickle.dump([self.theta,
+                        nn_weights,
+                        self.weights,
+                        self.number_networks,
+                        self.hidden_layers,
+                        self.learning_rate,
+                        self.cluster_number,
+                        self.cluster_labels], f)
+    
+    @classmethod
+    def load(cls, filename):
+        r"""
+
+        This function can be used to load a saved MAF. For example
+
+        .. code:: python
+
+            from ...maf import MAF
+
+            file = 'path/to/pickled/MAF.pkl'
+            bij = MAF.load(file)
+
+        **Parameters:**
+
+            filename: **string**
+                | Path to the saved MAF.
+
+        """
+
+        with open(filename, 'rb') as f:
+            data = pickle.load(f)
+            theta, nn_weights, \
+                sample_weights, \
+                number_networks, \
+                hidden_layers, \
+                learning_rate, \
+                cluster_number, \
+                labels = data
+
+        maf = cls(theta, sample_weights,
+                    number_networks=number_networks,
+                    hidden_layers=hidden_layers,
+                    learning_rate=learning_rate,
+                    cluster_number=cluster_number,
+                    cluster_labels=labels)
+        maf(np.random.uniform(size=(1, theta.shape[-1])))
+        for j in range(len(maf.flow)):
+            for made, nnw in zip(maf.flow[j].mades, nn_weights[j]):
+                    made.set_weights(nnw)
+
+        return maf

--- a/margarine/kde.py
+++ b/margarine/kde.py
@@ -150,9 +150,9 @@ class KDE(object):
                     method='bisect').root
             transformed_samples.append(
                 _inverse_transform(
-                tf.convert_to_tensor(y, dtype=tf.float32),
-                tf.convert_to_tensor(self.theta_min, dtype=tf.float32),
-                tf.convert_to_tensor(self.theta_max, dtype=tf.float32)))
+                    tf.convert_to_tensor(y, dtype=tf.float32),
+                    tf.convert_to_tensor(self.theta_min, dtype=tf.float32),
+                    tf.convert_to_tensor(self.theta_max, dtype=tf.float32)))
         transformed_samples = np.array(transformed_samples)
         return transformed_samples
 
@@ -255,7 +255,7 @@ class KDE(object):
         if prior is None:
             warnings.warn('Assuming prior is uniform!')
             prior_logprob = np.log(np.prod(
-                                    [1/(self.theta_max[i] - self.theta_min[i])
+                                   [1/(self.theta_max[i] - self.theta_min[i])
                                     for i in range(len(self.theta_min))]))
         else:
             self.prior = margarine.kde.KDE(prior, prior_weights)

--- a/margarine/kde.py
+++ b/margarine/kde.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.stats import gaussian_kde, norm
 from margarine.processing import _forward_transform, _inverse_transform
 from scipy.optimize import root_scalar
+import tensorflow as tf
 import pickle
 import warnings
 from tensorflow_probability import bijectors as tfb
@@ -96,8 +97,11 @@ class KDE(object):
         Function noramlises the input data into a standard normal parameter
         space and then generates a weighted KDE.
         """
+        theta = tf.convert_to_tensor(self.theta, dtype=tf.float32)
+        theta_min = tf.convert_to_tensor(self.theta_min, dtype=tf.float32)
+        theta_max = tf.convert_to_tensor(self.theta_max, dtype=tf.float32)
 
-        phi = _forward_transform(self.theta, self.theta_min, self.theta_max)
+        phi = _forward_transform(theta, theta_min, theta_max).numpy()
         mask = np.isfinite(phi).all(axis=-1)
         phi = phi[mask, :]
         weights_phi = self.sample_weights[mask]
@@ -145,7 +149,10 @@ class KDE(object):
                     bracket=(mu[:, i].min()*2, mu[:, i].max()*2),
                     method='bisect').root
             transformed_samples.append(
-                _inverse_transform(y, self.theta_min, self.theta_max))
+                _inverse_transform(
+                tf.convert_to_tensor(y, dtype=tf.float32),
+                tf.convert_to_tensor(self.theta_min, dtype=tf.float32),
+                tf.convert_to_tensor(self.theta_max, dtype=tf.float32)))
         transformed_samples = np.array(transformed_samples)
         return transformed_samples
 
@@ -167,7 +174,10 @@ class KDE(object):
 
         """
         x = self.kde.resample(length).T
-        return _inverse_transform(x, self.theta_min, self.theta_max)
+        return _inverse_transform(
+            tf.convert_to_tensor(x, dtype='float32'),
+            tf.convert_to_tensor(self.theta_min, dtype=tf.float32),
+            tf.convert_to_tensor(self.theta_max, dtype=tf.float32))
 
     def log_prob(self, params):
 
@@ -191,7 +201,9 @@ class KDE(object):
         maxs = self.theta_max.astype(np.float32)
 
         transformed_x = _forward_transform(
-            params, mins, maxs)
+            tf.convert_to_tensor(params, dtype=tf.float32),
+            tf.convert_to_tensor(mins, dtype=tf.float32),
+            tf.convert_to_tensor(maxs, dtype=tf.float32)).numpy()
 
         transform_chain = tfb.Chain([
             tfb.Invert(tfb.NormalCDF()),

--- a/margarine/kde.py
+++ b/margarine/kde.py
@@ -292,7 +292,7 @@ class KDE(object):
 
         .. code:: python
 
-            from bayesstats.kde import KDE
+            from margarine.kde import KDE
 
             file = 'path/to/pickled/bijector.pkl'
             KDE_class = KDE.load(file)

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -2,7 +2,7 @@ from typing import Any
 import tensorflow as tf
 from tensorflow import keras
 from tensorflow_probability import (bijectors as tfb, distributions as tfd)
-from margarine.new_processing import (_forward_transform, _inverse_transform,
+from margarine.processing import (_forward_transform, _inverse_transform,
                                       pure_tf_train_test_split)
 from sklearn.model_selection import train_test_split
 import numpy as np

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -147,7 +147,7 @@ class MAF():
 
         .. code:: python
 
-            from ...maf import MAF
+            from margarine.maf import MAF
 
             bij = MAF(theta, weights)
             bij.train()

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -169,7 +169,6 @@ class MAF():
                 maf.trainable_variables))
         return loss
     
-    @tf.function(jit_compile=True)
     def __call__(self, u):
         r"""
 
@@ -193,7 +192,6 @@ class MAF():
     
         return x
     
-    @tf.function(jit_compile=True)
     def sample(self, length=1000):
 
         r"""

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -1,154 +1,41 @@
-import numpy as np
+from typing import Any
 import tensorflow as tf
 from tensorflow import keras
 from tensorflow_probability import (bijectors as tfb, distributions as tfd)
-from margarine.processing import _forward_transform, _inverse_transform
-from sklearn.cluster import KMeans
-import pickle
+from margarine.new_processing import (_forward_transform, _inverse_transform,
+                                      pure_tf_train_test_split)
+from sklearn.model_selection import train_test_split
+import numpy as np
+import tqdm
 import warnings
 import margarine
-from scipy.special import logsumexp
-from sklearn.model_selection import train_test_split
-import tqdm 
+import pickle
 
 
-class MAF(object):
-
-    r"""
-
-    This class is used to train, load and call instances of a bijector
-    built from a series of autoregressive neural networks.
-
-    **Parameters:**
-
-        theta: **numpy array**
-            | The samples from the probability distribution that we require the
-                MAF to learn.
-
-        weights: **numpy array**
-            | The weights associated with the samples above.
-
-    **kwargs:**
-
-        number_networks: **int / default = 6**
-            | The bijector is built by chaining a series of
-                autoregressive neural
-                networks together and this parameter is used to determine
-                how many networks there are in the chain.
-
-        learning_rate: **float / default = 1e-3**
-            | The learning rate determines the 'step size' of the optimization
-                algorithm used to train the MAF. Its value can effect the
-                quality of emulation.
-
-        hidden_layers: **list / default = [50, 50]**
-            | The number of layers and number of nodes in each hidden layer for
-                each neural network. The default is two hidden layers with
-                50 nodes each and each network in the chain has the same hidden
-                layer structure.
-
-        theta_max: **numpy array**
-            | The true upper limits of the priors used to generate the samples
-                that we want the MAF to learn.
-
-        theta_min: **numpy array**
-            | As above but the true lower limits of the priors.
-
-        clustering: **Bool / default = False**
-            | Whether or not to perform clustering as in
-                https://arxiv.org/abs/2305.02930.
-
-        cluster_labels: **list / default = None**
-            | If clustering has been performed externally to margarine you can
-                provide a list of labels for the samples theta. The labels
-                should be integers from 0 to k corresponding to the cluster
-                that each sample is in. Clustering is turned on if cluster
-                labels are supplied.
-
-        cluster_number: **int / default = None**
-            | If clustering has been performed externally to margarine you
-                need to provide the number of clusters, k, alongside the
-                cluster labels.
-
-
-    **Attributes:**
-
-    A list of some key attributes accessible to the user.
-
-        maf: **Instance of tfd.TransformedDistribution**
-            | By loading a trained instance of this class and accessing the
-                ``maf`` (masked autoregressive flow) attribute, which is an
-                instance of
-                ``tensorflow_probability.distributions.TransformedDistribution``,
-                the used can sample the trained MAF. e.g.
-
-                .. code:: python
-
-                    from ...maf import MAF
-
-                    file = '/trained_maf.pkl'
-                    bij = MAF.load(file)
-
-                    samples = bij.maf.sample(1000)
-
-                It can also be used to calculate log probabilities via
-
-                .. code:: python
-
-                    log_prob = bij.log_prob(samples)
-
-                For more information on the attributes associated with
-                ``tensorflow_probability.distributions.TransformedDistribution``
-                see the tensorflow documentation.
-
-        theta_max: **numpy array**
-            | The true upper limits of the priors used to generate the
-                samples that we want the MAF to learn. If theta_max is not
-                supplied as a kwarg, then this is is an approximate estimate.
-
-        theta_min: **numpy array**
-            | As above but for the true lower limits of the priors. If
-                theta_max is not supplied as a kwarg, then this is is an
-                approximate estimate.
-
-        loss_history: **list**
-            | This list contains the value of the loss function at each epoch
-                during training.
-
-    """
+class MAF():
 
     def __init__(self, theta, weights, **kwargs):
         self.number_networks = kwargs.pop('number_networks', 6)
         self.learning_rate = kwargs.pop('learning_rate', 1e-3)
         self.hidden_layers = kwargs.pop('hidden_layers', [50, 50])
-        self.clustering = kwargs.pop('clustering', False)
-        self.cluster_labels = kwargs.pop('cluster_labels', None)
-        self.cluster_number = kwargs.pop('cluster_number', None)
 
-        if self.cluster_number is not None:
-            if self.cluster_labels is None:
-                raise ValueError("'cluster_labels' should be provided if " +
-                                 "'cluster_number' is specified.")
-        else:
-            if self.cluster_labels is not None:
-                raise ValueError("'cluster_number' should be provided if " +
-                                 "'cluster_labels' is specified.")
+        self.theta = tf.convert_to_tensor(theta, dtype=tf.float32)
+        self.sample_weights = tf.convert_to_tensor(weights, dtype=tf.float32)
 
-        if self.cluster_labels is not None and self.cluster_number is not None:
-            self.clustering = True
+        mask = np.isfinite(theta).all(axis=-1)
+        self.theta = tf.boolean_mask(self.theta, mask, axis=0)
+        self.sample_weights = tf.boolean_mask(self.sample_weights, mask, axis=0)
 
-        self.n = (np.sum(weights)**2)/(np.sum(weights**2))
-        self.sample_weights = weights
-
-        theta_max = np.max(theta, axis=0)
-        theta_min = np.min(theta, axis=0)
+        self.n = tf.math.reduce_sum(self.sample_weights)**2/ \
+            tf.math.reduce_sum(self.sample_weights**2)
+        
+        theta_max = tf.math.reduce_max(self.theta, axis=0)
+        theta_min = tf.math.reduce_min(self.theta, axis=0)
         a = ((self.n-2)*theta_max-theta_min)/(self.n-3)
         b = ((self.n-2)*theta_min-theta_max)/(self.n-3)
         self.theta_min = kwargs.pop('theta_min', b)
         self.theta_max = kwargs.pop('theta_max', a)
-
-        self.theta = theta
-
+        
         if type(self.number_networks) is not int:
             raise TypeError("'number_networks' must be an integer.")
         if not isinstance(self.learning_rate,
@@ -164,23 +51,12 @@ class MAF(object):
                     raise TypeError(
                         "One or more valus in 'hidden_layers'" +
                         "is not an integer.")
-
+        
         self.optimizer = tf.keras.optimizers.legacy.Adam(
                 learning_rate=self.learning_rate)
-
-        if self.clustering is False:
-            self.gen_mades()
-            self.cluster_number = None
-        if self.clustering is True:
-            if self.cluster_number is not None:
-                if self.cluster_number%1!=0:
-                    raise TypeError("'cluster_number' must be a whole number.")
-            if self.cluster_labels is not None:
-                if not isinstance(self.cluster_labels, (np.ndarray, list)):
-                    raise TypeError("'cluster_labels' must be an array " +
-                                    "or a list.")
-            self.clustering_call()
-
+        
+        self.gen_mades()
+        
     def gen_mades(self):
 
         """Generating the masked autoregressive flow."""
@@ -200,132 +76,9 @@ class MAF(object):
         self.maf = tfd.TransformedDistribution(self.base, bijector=self.bij)
 
         return self.bij, self.maf
-
-    def clustering_call(self):
-
-        """Generating a piecewise masked autoregressive
-        flow with clustering."""
-
-        if self.cluster_number is None:
-            from sklearn.metrics import silhouette_score
-            ks = np.arange(2, 21)
-            losses = []
-            for k in ks:
-                kmeans = KMeans(k, random_state=0)
-                labels = kmeans.fit(self.theta).predict(self.theta)
-                losses.append(-silhouette_score(self.theta, labels))
-            losses = np.array(losses)
-            minimum_index = np.argmin(losses)
-            self.cluster_number = ks[minimum_index]
-
-            kmeans = KMeans(self.cluster_number, random_state=0)
-            self.cluster_labels = kmeans.fit(self.theta).predict(self.theta)
-        
-        if self.cluster_number == 20:
-            warnings.warn("The number of clusters is 20. This is the maximum "+
-                            "number of clusters that can be used. If you " +
-                            "require more clusters, please specify the " +
-                            "'cluster_number' kwarg. margarine will continue "+
-                            "with 20 clusters.")
-        
-        if np.array(list(self.cluster_labels)).dtype == 'float':
-            # convert cluster labels to integers
-            self.cluster_labels = self.cluster_labels.astype(int)
-        # count the number of times a cluster label appears in cluster_labels
-        self.cluster_count = np.bincount(self.cluster_labels)
-        # While loop to make sure clusters are not too small
-        while self.cluster_count.min() < 100:
-            warnings.warn("One or more clusters are too small " +
-                          "(n_cluster < 100). " +
-                          "Reducing the number of clusters by 1.")
-            minimum_index -= 1
-            self.cluster_number = ks[minimum_index]
-            kmeans = KMeans(self.cluster_number, random_state=0)
-            self.cluster_labels = kmeans.fit(self.theta).predict(self.theta)
-            self.cluster_count = np.bincount(self.cluster_labels)
-            if self.cluster_number == 2:
-                # break if two clusters
-                warnings.warn("The number of clusters is 2. This is the " +
-                            "minimum number of clusters that can be used. " +
-                            "Some clusters may be too small and the " +
-                            "train/test split may fail." +
-                            "Try running without clusting. ")
-                break
-
-        self.n, split_theta, self.new_theta_max = [], [], []
-        self.new_theta_min, split_sample_weights = [], []
-        self.bij, self.maf, self.mades = [], [], []
-        for i in range(self.cluster_number):
-            theta = self.theta[self.cluster_labels == i]
-            split_sample_weights.append(
-                self.sample_weights[self.cluster_labels == i])
-
-            self.n.append(
-                (np.sum(self.sample_weights[self.cluster_labels == i])**2) /
-                (np.sum(self.sample_weights[self.cluster_labels == i]**2)))
-
-            if not any(isinstance(tm, list) for tm in self.theta_max):
-                new_theta_max = np.max(theta, axis=0)
-                new_theta_min = np.min(theta, axis=0)
-                a = ((self.n[-1]-2)*new_theta_max-new_theta_min)/(self.n[-1]-3)
-                b = ((self.n[-1]-2)*new_theta_min-new_theta_max)/(self.n[-1]-3)
-                self.new_theta_min.append(b)
-                self.new_theta_max.append(a)
-
-            split_theta.append(theta)
-
-            self.mades.append(
-                [tfb.AutoregressiveNetwork(
-                            params=2,
-                            hidden_units=self.hidden_layers, activation='tanh',
-                            input_order='random')
-                    for _ in range(self.number_networks)])
-
-            self.bij.append(tfb.Chain([
-                tfb.MaskedAutoregressiveFlow(made)
-                for made in self.mades[-1]]))
-
-            self.base = tfd.Blockwise(
-                [tfd.Normal(loc=0, scale=1)
-                    for _ in range(self.theta.shape[-1])])
-
-            self.maf.append(tfd.TransformedDistribution(
-                self.base, bijector=self.bij[-1]))
-        self.theta = split_theta
-        self.sample_weights = split_sample_weights
-        if self.new_theta_max != []:
-            self.theta_max = self.new_theta_max
-            self.theta_min = self.new_theta_min
-
+    
     def train(self, epochs=100, early_stop=False, loss_type='sum'):
-        r"""
-
-        This function is called to train the MAF once it has been
-        initialised. It calls `_training()` for each MAF whether there
-        is only one or whether clustering is turned on. For example
-
-        .. code:: python
-
-            from ...maf import MAF
-
-            bij = MAF(theta, weights)
-            bij.train()
-
-        **Kwargs:**
-
-            epochs: **int / default = 100**
-                | The number of iterations to train the neural networks for.
-
-            early_stop: **boolean / default = False**
-                | Determines whether or not to implement an early stopping
-                    algorithm or
-                    train for the set number of epochs. If set to True then the
-                    algorithm will stop training when test loss has not
-                    improved for 2% of the requested epochs. At this point
-                    margarine will roll back to the best model and return this
-                    to the user.
-
-        """
+        
         if type(epochs) is not int:
             raise TypeError("'epochs' is not an integer.")
         if type(early_stop) is not bool:
@@ -335,53 +88,33 @@ class MAF(object):
         self.early_stop = early_stop
         self.loss_type = loss_type
 
-        if self.cluster_number is not None:
-            for i in range(len(self.theta)):
-                self.maf[i] = self._training(self.theta[i],
-                                             self.sample_weights[i],
-                                             self.maf[i], self.theta_min[i],
-                                             self.theta_max[i])
-        else:
-            self.maf = self._training(self.theta,
-                                      self.sample_weights, self.maf,
-                                      self.theta_min, self.theta_max)
-
+        self.maf = self._training(self.theta,
+                                    self.sample_weights, self.maf,
+                                    self.theta_min, self.theta_max)
+    
     def _training(self, theta, sample_weights, maf,
                   theta_min, theta_max):
-
-        """Function to perform the training of each MAF."""
-
+        
+        """Training the masked autoregressive flow."""
+        
         phi = _forward_transform(theta, theta_min, theta_max)
-
-        mask = np.isfinite(phi).all(axis=-1)
-        phi = phi[mask, :]
-        weights_phi = sample_weights[mask]
-        weights_phi /= weights_phi.sum()
-
-        phi = phi.astype('float32')
-        self.phi = phi.copy()
-        weights_phi = weights_phi.astype('float32')
+        weights_phi = sample_weights/tf.reduce_sum(sample_weights)
 
         phi_train, phi_test, weights_phi_train, weights_phi_test = \
-            train_test_split(phi, weights_phi, test_size=0.2)
-
+            pure_tf_train_test_split(phi, weights_phi, test_size=0.2)
+        
         self.loss_history = []
         self.test_loss_history = []
         c = 0
         for i in tqdm.tqdm(range(self.epochs)):
             loss = self._train_step(phi_train,
                                     weights_phi_train,
-                                    self.loss_type, maf).numpy()
+                                    self.loss_type, maf)
             self.loss_history.append(loss)
 
-            if self.loss_type == 'sum':
-                loss_test = -tf.reduce_sum(
-                    weights_phi_test*maf.log_prob(phi_test))
-            elif self.loss_type == 'mean':
-                loss_test = -tf.reduce_mean(
-                    weights_phi_test*maf.log_prob(phi_test))
-
-            self.test_loss_history.append(loss_test)
+            self.test_loss_history.append(self._test_step(phi_test, 
+                                        weights_phi_test,
+                                        self.loss_type, maf))
 
             if self.early_stop:
                 c += 1
@@ -402,7 +135,21 @@ class MAF(object):
                         return minimum_model
         return maf
     
-    #@tf.function(jit_compile=True)
+    @tf.function(jit_compile=True)
+    def _test_step(self,x, w, loss_type, maf):
+
+        r"""
+        This function is used to calculate the test loss value at each epoch
+        for early stopping.
+        """
+
+        if loss_type == 'sum':
+                loss = -tf.reduce_sum(w*maf.log_prob(x))
+        elif loss_type == 'mean':
+            loss = -tf.reduce_mean(w*maf.log_prob(x))
+        return loss
+
+    @tf.function(jit_compile=True)
     def _train_step(self, x, w, loss_type, maf):
 
         r"""
@@ -421,9 +168,9 @@ class MAF(object):
             zip(gradients,
                 maf.trainable_variables))
         return loss
-
+    
+    @tf.function(jit_compile=True)
     def __call__(self, u):
-
         r"""
 
         This function is used when calling the MAF class to transform
@@ -435,35 +182,18 @@ class MAF(object):
                 | Samples on the uniform hypercube.
 
         """
+        #print(u)
+        #u = tf.convert_to_tensor(u, dtype=tf.float32)
+        u = tf.cast(u, dtype=tf.float32)
 
-        if self.cluster_number is not None:
-            len_thetas = [len(self.theta[i]) for i in range(len(self.theta))]
-            probabilities = [len_thetas[i]/np.sum(len_thetas)
-                             for i in range(len(self.theta))]
-            options = np.arange(0, self.cluster_number)
-            choice = np.random.choice(options,
-                                      p=probabilities, size=len(u))
-
-            totals = [len(choice[choice == options[i]])
-                      for i in range(len(options))]
-            totals = np.hstack([0, np.cumsum(totals)])
-
-            values = []
-            for i in range(len(options)):
-                x = _forward_transform(u[totals[i]:totals[i+1]])
-                x = self.bij[i](x.astype(np.float32)).numpy()
-                values.append(_inverse_transform(x, self.theta_min[i],
-                                                 self.theta_max[i]))
-
-            x = np.concatenate(values)
-        else:
-            x = _forward_transform(u)
-            x = self.bij(x.astype(np.float32)).numpy()
-            x = _inverse_transform(x, self.theta_min, self.theta_max)
-
-        mask = np.isfinite(x).all(axis=-1)
-        return x[mask, ...]
-
+        
+        x = _forward_transform(u)
+        x = self.bij(x)
+        x = _inverse_transform(x, self.theta_min, self.theta_max)
+    
+        return x
+    
+    @tf.function(jit_compile=True)
     def sample(self, length=1000):
 
         r"""
@@ -480,13 +210,11 @@ class MAF(object):
         """
         if type(length) is not int:
             raise TypeError("'length' must be an integer.")
-
-        if self.cluster_number is not None:
-            u = np.random.uniform(0, 1, size=(length, self.theta[0].shape[-1]))
-        else:
-            u = np.random.uniform(0, 1, size=(length, self.theta.shape[-1]))
+        
+        u = tf.random.uniform((length, len(self.theta_min)))
         return self(u)
-
+    
+    @tf.function(jit_compile=True)
     def log_prob(self, params):
 
         """
@@ -512,7 +240,7 @@ class MAF(object):
 
             def norm_jac(y):
                 return transform_chain.inverse_log_det_jacobian(
-                    y, event_ndims=0).numpy()
+                    y, event_ndims=0)
 
             transformed_x = _forward_transform(params, mins, maxs)
 
@@ -521,27 +249,12 @@ class MAF(object):
                 tfb.Scale(1/(maxs - mins)), tfb.Shift(-mins)])
 
             correction = norm_jac(transformed_x)
-            logprob = (maf.log_prob(transformed_x).numpy() -
-                       np.sum(correction, axis=-1)).astype(np.float64)
+            logprob = (maf.log_prob(transformed_x) -
+                       tf.reduce_sum(correction, axis=-1))
             return logprob
-
-        if self.clustering is True:
-            logprob = []
-            for i in range(len(self.theta_min)):
-                mins = self.theta_min[i].astype(np.float32)
-                maxs = self.theta_max[i].astype(np.float32)
-                probs = calc_log_prob(mins, maxs, self.maf[i])
-                for j in range(len(probs)):
-                    if np.isnan(probs[j]):
-                        probs[j] = np.log(1e-300)
-                logprob.append(probs)
-            logprob = np.array(logprob)
-            logprob = logsumexp(logprob, axis=0)
-        else:
-            mins = self.theta_min.astype(np.float32)
-            maxs = self.theta_max.astype(np.float32)
-            logprob = calc_log_prob(mins, maxs, self.maf)
-
+        
+        logprob = calc_log_prob(self.theta_min, self.theta_max, self.maf)
+        
         return logprob
 
     def log_like(self, params, logevidence, prior=None, prior_weights=None):
@@ -575,11 +288,11 @@ class MAF(object):
                 | Weights to go with the prior samples.
 
         """
-
+    
         if prior is None:
             warnings.warn('Assuming prior is uniform!')
-            prior_logprob = np.log(
-                np.prod([1/(self.theta_max[i] - self.theta_min[i])
+            prior_logprob = tf.math.log(
+                tf.math.reduce_prod([1/(self.theta_max[i] - self.theta_min[i])
                          for i in range(len(self.theta_min))]))
         else:
             self.prior = margarine.maf.MAF(prior, prior_weights)
@@ -592,7 +305,7 @@ class MAF(object):
         loglike = posterior_logprob + logevidence - prior_logprob
 
         return loglike
-
+    
     def save(self, filename):
         r"""
 
@@ -606,27 +319,9 @@ class MAF(object):
                 | Path in which to save the pickled MAF.
 
         """
-        if self.cluster_number is None:
-            nn_weights = [made.get_weights() for made in self.mades]
-        else:
-            nn_weights = {}
-            for i in range(self.cluster_number):
-                made = self.mades[i]
-                w = [m.get_weights() for m in made]
-                nn_weights[i] = w
+
+        nn_weights = [made.get_weights() for made in self.mades]
         with open(filename, 'wb') as f:
-            if self.clustering is True:
-                pickle.dump([self.theta,
-                            nn_weights,
-                            self.sample_weights,
-                            self.number_networks,
-                            self.hidden_layers,
-                            self.learning_rate,
-                            self.theta_min,
-                            self.theta_max,
-                            self.cluster_number,
-                            self.cluster_labels], f)
-            else:
                 pickle.dump([self.theta,
                             nn_weights,
                             self.sample_weights,
@@ -635,7 +330,7 @@ class MAF(object):
                             self.learning_rate,
                             self.theta_min,
                             self.theta_max], f)
-
+                
     @classmethod
     def load(cls, filename):
         r"""
@@ -658,49 +353,19 @@ class MAF(object):
 
         with open(filename, 'rb') as f:
             data = pickle.load(f)
-            try:
-                theta, nn_weights, \
-                    sample_weights, \
-                    number_networks, \
-                    hidden_layers, \
-                    learning_rate, theta_min, theta_max = data
-                cluster_number = None
-            except Exception:
-                theta, nn_weights, \
-                    sample_weights, \
-                    number_networks, \
-                    hidden_layers, \
-                    learning_rate, theta_min, theta_max, \
-                    cluster_number, \
-                    labels = data
-
-        if cluster_number is None:
-            bijector = cls(
-                theta, sample_weights, number_networks=number_networks,
-                learning_rate=learning_rate, hidden_layers=hidden_layers,
-                theta_min=theta_min, theta_max=theta_max)
-            bijector(
-                np.random.uniform(0, 1, size=(len(theta), theta.shape[-1])))
-            for made, nn_weights in zip(bijector.mades, nn_weights):
-                made.set_weights(nn_weights)
-        else:
-            # have to sort labels because theta is reordered when
-            # it gets concatenated
-            labels.sort()
-            theta = np.concatenate(theta)
-            sample_weights = np.concatenate(sample_weights)
-            bijector = cls(
-                theta, sample_weights, number_networks=number_networks,
-                learning_rate=learning_rate, hidden_layers=hidden_layers,
-                clustering=True,
-                cluster_number=cluster_number, cluster_labels=labels,
-                theta_min=theta_min, theta_max=theta_max)
-            bijector(
-                np.random.uniform(0, 1, size=(len(theta), theta.shape[-1])))
-            for i in range(cluster_number):
-                mades = bijector.mades[i]
-                weights = nn_weights[i]
-                for m, w in zip(mades, weights):
-                    m.set_weights(w)
+            theta, nn_weights, \
+                sample_weights, \
+                number_networks, \
+                hidden_layers, \
+                learning_rate, theta_min, theta_max = data
+            
+        bijector = cls(
+            theta, sample_weights, number_networks=number_networks,
+            learning_rate=learning_rate, hidden_layers=hidden_layers,
+            theta_min=theta_min, theta_max=theta_max)
+        bijector(
+            np.random.uniform(0, 1, size=(len(theta), theta.shape[-1])))
+        for made, nn_weights in zip(bijector.mades, nn_weights):
+            made.set_weights(nn_weights)
 
         return bijector

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -58,32 +58,6 @@ class MAF():
 
     A list of some key attributes accessible to the user.
 
-        maf: **Instance of tfd.TransformedDistribution**
-            | By loading a trained instance of this class and accessing the
-                ``maf`` (masked autoregressive flow) attribute, which is an
-                instance of
-                ``tensorflow_probability.distributions.TransformedDistribution``,
-                the used can sample the trained MAF. e.g.
-
-                .. code:: python
-
-                    from ...maf import MAF
-
-                    file = '/trained_maf.pkl'
-                    bij = MAF.load(file)
-
-                    samples = bij.maf.sample(1000)
-
-                It can also be used to calculate log probabilities via
-
-                .. code:: python
-
-                    log_prob = bij.log_prob(samples)
-
-                For more information on the attributes associated with
-                ``tensorflow_probability.distributions.TransformedDistribution``
-                see the tensorflow documentation.
-
         theta_max: **numpy array**
             | The true upper limits of the priors used to generate the
                 samples that we want the MAF to learn. If theta_max is not
@@ -450,7 +424,7 @@ class MAF():
 
         .. code:: python
 
-            from ...maf import MAF
+            from margarine.maf import MAF
 
             file = 'path/to/pickled/MAF.pkl'
             bij = MAF.load(file)

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -169,6 +169,7 @@ class MAF():
                 maf.trainable_variables))
         return loss
     
+    @tf.function(jit_compile=True)
     def __call__(self, u):
         r"""
 
@@ -192,6 +193,7 @@ class MAF():
     
         return x
     
+    @tf.function(jit_compile=True)
     def sample(self, length=1000):
 
         r"""

--- a/margarine/marginal_stats.py
+++ b/margarine/marginal_stats.py
@@ -1,7 +1,5 @@
 import numpy as np
 from tensorflow_probability import distributions as tfd
-import margarine
-import warnings
 import pandas as pd
 from margarine.maf import MAF
 
@@ -50,7 +48,7 @@ class calculate(object):
 
         prior_de: **instance of MAF class, clusterMAF class or KDE class**
             | This should be a loaded and trained instance of a MAF, clusterMAF
-                or KDE for the prior. 
+                or KDE for the prior.
                 If not provided, a uniform prior will be used.
 
     """
@@ -68,7 +66,7 @@ class calculate(object):
             self.theta_weights = self.theta_weights.numpy()
             self.theta_min = self.theta_min.numpy()
             self.theta_max = self.theta_max.numpy()
-    
+
         self.samples = self.de.sample(len(self.theta))
 
         self.prior_de = kwargs.pop('prior_de', None)
@@ -82,7 +80,7 @@ class calculate(object):
 
         def mask_arr(arr):
             return arr[np.isfinite(arr)], np.isfinite(arr)
-        
+
         logprob = self.de.log_prob(self.samples)
         theta_logprob = self.de.log_prob(self.theta)
 
@@ -123,7 +121,7 @@ class calculate(object):
         elif self.prior_de is not None:
             self.base = self.prior_de.copy()
             de_prior_samples = self.base.sample(len(self.theta))
-            theta_base_logprob = self.base.log_prob(self.prior_samples)
+            theta_base_logprob = self.base.log_prob(de_prior_samples)
             base_logprob = self.base.log_prob(self.theta)
 
             if isinstance(self.prior_de, MAF):
@@ -136,7 +134,7 @@ class calculate(object):
 
             base_args = np.argsort(theta_base_logprob)
             theta_base_logprob = theta_base_logprob[base_args]
-            prior_weights = np.cumsum(self.prior_weights[base_args])
+            prior_weights = np.cumsum(self.prior_de.sample_weights[base_args])
 
             prior_weights = (np.cumsum(self.theta_weights).max() -
                              np.cumsum(self.theta_weights).min()) * \

--- a/margarine/marginal_stats.py
+++ b/margarine/marginal_stats.py
@@ -17,19 +17,23 @@ class calculate(object):
     **Paramesters:**
 
         de: **instance of MAF class or KDE class**
-            | This should be a loaded and trained instance of a MAF or KDE.
-                Bijectors can be loaded like so
+            | This should be a loaded and trained instance of a MAF, clusterMAF
+                or KDE.Bijectors can be loaded like so
 
                 .. code:: python
 
                     from margarine.maf import MAF
                     from margarine.kde import KDE
+                    from margarine.clustered import clusterMAF
 
                     file = '/trained_maf.pkl'
                     maf = MAF.load(file)
 
                     file = '/trained_kde.pkl'
                     kde = KDE.load(file)
+
+                    file = '/trained_clustered_maf.pkl'
+                    clustered_maf = clusterMAF.load(file)
 
         samples: **numpy array**
             | This should be the output of the bijector when called to generate
@@ -44,14 +48,10 @@ class calculate(object):
 
     **Kwargs:**
 
-        prior_samples: **numpy array / default=None**
-            | Can be provided if the prior is non-uniform and will be
-                used to generate a prior density estimator to calcualte
-                prior log-probabilities. If not provided the prior is
-                assumed to be uniform.
-
-        prior_weights: **numpy array / default=None**
-            | Weights associated with the above prior samples.
+        prior_de: **instance of MAF class, clusterMAF class or KDE class**
+            | This should be a loaded and trained instance of a MAF, clusterMAF
+                or KDE for the prior. 
+                If not provided, a uniform prior will be used.
 
     """
 
@@ -74,6 +74,11 @@ class calculate(object):
         self.prior_de = kwargs.pop('prior_de', None)
 
     def statistics(self):
+
+        """
+        Calculate marginal bayesian KL divergence and dimensionality with
+        approximate errors.
+        """
 
         def mask_arr(arr):
             return arr[np.isfinite(arr)], np.isfinite(arr)

--- a/margarine/marginal_stats.py
+++ b/margarine/marginal_stats.py
@@ -4,7 +4,6 @@ import margarine
 import warnings
 import pandas as pd
 from margarine.maf import MAF
-from margarine.kde import KDE
 
 
 class calculate(object):

--- a/margarine/processing.py
+++ b/margarine/processing.py
@@ -71,20 +71,22 @@ def pure_tf_train_test_split(a, b, test_size=0.2):
 
         a: **array**
             | Samples to be split.
-        
+
         b: **array**
             | Weights to be split.
-        
+
         test_size: **float**
             | Fraction of data to be used for testing.
     """
 
     idx = random.sample(range(len(a)), int(len(a)*test_size))
 
-    a_train = tf.gather(a, 
-            tf.convert_to_tensor(list(set(range(len(a))) - set(idx))))
-    b_train = tf.gather(b, 
-            tf.convert_to_tensor(list(set(range(len(b))) - set(idx))))
+    a_train = tf.gather(a,
+                        tf.convert_to_tensor(
+                            list(set(range(len(a))) - set(idx))))
+    b_train = tf.gather(b,
+                        tf.convert_to_tensor(
+                            list(set(range(len(b))) - set(idx))))
     a_test = tf.gather(a, tf.convert_to_tensor(idx))
     b_test = tf.gather(b, tf.convert_to_tensor(idx))
 

--- a/margarine/processing.py
+++ b/margarine/processing.py
@@ -1,6 +1,9 @@
 from tensorflow_probability import distributions as tfd
+import tensorflow as tf
+import random
 
 
+@tf.function(jit_compile=True)
 def _forward_transform(x, min=0, max=1):
     r"""
 
@@ -24,11 +27,12 @@ def _forward_transform(x, min=0, max=1):
                 values...)
 
     """
-    x = tfd.Uniform(min, max).cdf(x).numpy()
-    x = tfd.Normal(0, 1).quantile(x).numpy()
+    x = tfd.Uniform(min, max).cdf(x)
+    x = tfd.Normal(0, 1).quantile(x)
     return x
 
 
+@tf.function(jit_compile=True)
 def _inverse_transform(x, min, max):
     r"""
 
@@ -51,6 +55,37 @@ def _inverse_transform(x, min, max):
                 values...)
 
     """
-    x = tfd.Normal(0, 1).cdf(x).numpy()
-    x = tfd.Uniform(min, max).quantile(x).numpy()
+    x = tfd.Normal(0, 1).cdf(x)
+    x = tfd.Uniform(min, max).quantile(x)
     return x
+
+
+def pure_tf_train_test_split(a, b, test_size=0.2):
+
+    """
+    Splitting data into training and testing sets. Function is equivalent
+    to sklearn.model_selection.train_test_split but a and b
+    are tensorflow tensors.
+
+    **parameters:**
+
+        a: **array**
+            | Samples to be split.
+        
+        b: **array**
+            | Weights to be split.
+        
+        test_size: **float**
+            | Fraction of data to be used for testing.
+    """
+
+    idx = random.sample(range(len(a)), int(len(a)*test_size))
+
+    a_train = tf.gather(a, 
+            tf.convert_to_tensor(list(set(range(len(a))) - set(idx))))
+    b_train = tf.gather(b, 
+            tf.convert_to_tensor(list(set(range(len(b))) - set(idx))))
+    a_test = tf.gather(a, tf.convert_to_tensor(idx))
+    b_test = tf.gather(b, tf.convert_to_tensor(idx))
+
+    return a_train, a_test, b_train, b_test

--- a/notebook/Tutorial.ipynb
+++ b/notebook/Tutorial.ipynb
@@ -228,7 +228,7 @@
    "source": [
     "# Clustering with margarine\n",
     "\n",
-    "The below example demonstrates how to perform clustering with `margarine` which can improve the accuracy of the emulation."
+    "The below example demonstrates how to perform clustering with `margarine` which can improve the accuracy of the emulation. The clustering class has all the same functionality as the MAF class."
    ]
   },
   {
@@ -254,7 +254,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flow = MAF(data, np.ones(len(data)), clustering=True)\n",
+    "from margarine.clustered import clusterMAF\n",
+    "flow = clusterMAF(data, np.ones(len(data)))\n",
     "flow.train(10000, early_stop=True)"
    ]
   },

--- a/notebook/Tutorial.ipynb
+++ b/notebook/Tutorial.ipynb
@@ -81,7 +81,7 @@
    "source": [
     "## Masked Autoregressive Flows\n",
     "\n",
-    "Firstly we will look at training a Masked Autoregressive Flow or MAF with `margarine`. To train the MAF we first need to initalise the class with the samples and corresponding weights."
+    "Firstly we will look at training a Masked Autoregressive Flow or MAF with `margarine`. To train the MAF we first need to initalise the class with the samples and corresponding weights. For all of the different density estimators in `margarine` the weights have to be provided by the kwarg `weights` else they are assumed to be equal unless `theta` is an instance of anesthetic.samples."
    ]
   },
   {
@@ -96,7 +96,7 @@
     "\n",
     "from margarine.maf import MAF\n",
     "\n",
-    "bij = MAF(data, weights)\n",
+    "bij = MAF(data, weights=weights)\n",
     "bij.train(10000, early_stop=True)"
    ]
   },
@@ -187,7 +187,7 @@
    "outputs": [],
    "source": [
     "from margarine.kde import KDE\n",
-    "kde = KDE(data, weights)\n",
+    "kde = KDE(data, weights=weights)\n",
     "kde.generate_kde()\n",
     "x = kde.sample(5000)\n",
     "\n",
@@ -255,7 +255,7 @@
    "outputs": [],
    "source": [
     "from margarine.clustered import clusterMAF\n",
-    "flow = clusterMAF(data, np.ones(len(data)))\n",
+    "flow = clusterMAF(data)\n",
     "flow.train(10000, early_stop=True)"
    ]
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
-tensorflow
+tensorflow-macos; sys_platform == 'darwin'
+tensorflow; sys_platform != 'darwin'
 tensorflow_probability
 scipy
 pandas

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='0.6.0',
+    version='1.0.0',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -1,6 +1,6 @@
 import numpy as np
 from anesthetic import MCMCSamples
-from margarine.maf import MAF
+from margarine.clustered import clusterMAF
 from margarine.marginal_stats import calculate
 import pytest
 from numpy.testing import assert_equal, assert_allclose
@@ -30,16 +30,16 @@ names = [i for i in range(theta.shape[-1])]
 
 def test_maf_clustering():
 
-    bij = MAF(theta, weights, clustering=True)
+    bij = clusterMAF(theta, weights)
     bij.train(10000, early_stop=True)
     file = 'saved_maf_cluster.pkl'
     bij.save(file)
 
-    loaded_bijector = MAF.load('saved_maf_cluster.pkl')
-    for i in range(len(bij.mades)):
-        for j in range(len(bij.mades[i])):
-            assert_equal(bij.mades[i][j].get_weights(),
-                loaded_bijector.mades[i][j].get_weights())
+    loaded_bijector = clusterMAF.load('saved_maf_cluster.pkl')
+    for f in range(len(bij.flow)):
+        for i in range(len(bij.flow[f].mades)):
+            assert_equal(bij.flow[f].mades[i].get_weights(),
+                loaded_bijector.flow[f].mades[i].get_weights())
 
     def check_stats(i):
         if i ==0:
@@ -63,15 +63,12 @@ def test_maf_clustering():
 def test_maf_cluster_kwargs():
 
     with pytest.raises(ValueError):
-        bij = MAF(theta, weights, cluster_number=3)
+        bij = clusterMAF(theta, weights, cluster_number=3)
     with pytest.raises(ValueError):
-        bij = MAF(theta, weights, cluster_labels=np.ones(len(theta)))
+        bij = clusterMAF(theta, weights, cluster_labels=np.ones(len(theta)))
     
     labels = np.ones(len(theta))
     labels[:len(theta)//2] = 0
-    bij = MAF(theta, weights, cluster_number=2, 
-              cluster_labels=labels)
-    assert_equal(bij.clustering, True)
 
 def test_cluster_size():
     # testing the while loop for cluster size
@@ -80,5 +77,5 @@ def test_cluster_size():
                 np.zeros(ndims), np.eye(ndims), ndims*10)
 
     samples = draw(3)
-    flow = MAF(samples, np.ones(len(samples)), clustering=True)
+    flow = clusterMAF(samples, np.ones(len(samples)))
     return 0

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -30,7 +30,7 @@ names = [i for i in range(theta.shape[-1])]
 
 def test_maf_clustering():
 
-    bij = clusterMAF(theta, weights)
+    bij = clusterMAF(theta, weights=weights)
     bij.train(10000, early_stop=True)
     file = 'saved_maf_cluster.pkl'
     bij.save(file)
@@ -63,9 +63,10 @@ def test_maf_clustering():
 def test_maf_cluster_kwargs():
 
     with pytest.raises(ValueError):
-        bij = clusterMAF(theta, weights, cluster_number=3)
+        bij = clusterMAF(theta, weights=weights, cluster_number=3)
     with pytest.raises(ValueError):
-        bij = clusterMAF(theta, weights, cluster_labels=np.ones(len(theta)))
+        bij = clusterMAF(theta, weightes=weights, 
+                         cluster_labels=np.ones(len(theta)))
     
     labels = np.ones(len(theta))
     labels[:len(theta)//2] = 0
@@ -77,5 +78,4 @@ def test_cluster_size():
                 np.zeros(ndims), np.eye(ndims), ndims*10)
 
     samples = draw(3)
-    flow = clusterMAF(samples, np.ones(len(samples)))
-    return 0
+    flow = clusterMAF(samples)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -58,7 +58,7 @@ def test_maf():
     for i in range(len(p_values)):
         assert(round(p_values[i], 2) >0.05)
 
-    estL = bij.log_like(equal_weight_theta, 0.0)
+    estL = bij.log_like(equal_weight_theta.astype(np.float32), 0.0)
     check_like = 0
     for i in range(len(logL)):
         if np.isclose(np.exp(logL[i]), np.exp(estL[i]), rtol=1, atol=1):


### PR DESCRIPTION
This is a big breaking change PR for bumping to version 1.0.0. This PR tackles some of the issues discussed in the merged #26 and closed #31 and fully addresses the nebulous issue #20.

I've rewritten the MAF class so that it works exclusively with tensorflow and isn't constantly converting between numpy arrays and tensors. I've also added `tf.function` decorators where possible to speed up the training/sampling. 

I've also separated out the clustering into a separate class that calls `maf.py` rather than wrapping this functionality inside `maf.py`. This seems to resolve the issues with `tf.function` seen in #26 and allows us to take advantage of all the runtime improvements when using clustering. It will also make #30 easier to implement in the future I imagine.

I am planning to benchmark this against version 0.6.0 on a series of tasks like training, sampling etc for both normal mafs and clustering to quantify the improvements in runtime.

To Do:

- [x] updated documentation for `maf.py` and `processing.py`.
- [x] New documentation for `clustered.py`
- [x] updated tutorials
- [ ] updated pip install (post merging)
- [x] flake8 checks
- [x] update tests
- [x] bring `kde.py` in line with new preprocessing tools.
- [x] should write a test to see if the stats code works with the cluster code still

