### PR TITLE
Updating sample minimum/max handling for cluster maf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.0.2
+:Version: 1.0.3
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -209,7 +209,9 @@ class clusterMAF():
                                  weights=split_sample_weights[i],
                                  number_networks=self.number_networks,
                                  learning_rate=self.learning_rate,
-                                 hidden_layers=self.hidden_layers))
+                                 hidden_layers=self.hidden_layers,
+                                 theta_min=self.theta_min,
+                                 theta_max=self.theta_max))
 
     def train(self, epochs=100, early_stop=False, loss_type='sum'):
 
@@ -273,9 +275,6 @@ class clusterMAF():
         logprob = []
         for flow in self.flow:
             probs = flow.log_prob(params).numpy()
-            for j in range(len(probs)):
-                if np.isnan(probs[j]):
-                    probs[j] = np.log(1e-300)
             logprob.append(probs)
         logprob = np.array(logprob)
         logprob = logsumexp(logprob, axis=0)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='1.0.2',
+    version='1.0.3',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',


### PR DESCRIPTION
The clusterMAF components were previously normalised based on the bounds of the cluster. This is fine but causes issues when calculating log probabilities for samples outside the bounds of the cluster. I'd fixed this with a catch that set the log-probability of these samples to 1e-300. However, a perhaps better way to deal with this is to normalise the clusters with the range of the target distributions, as in this PR.