### PR TITLE
Flow weighting in clusterMAF

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.0.1
+:Version: 1.0.2
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.0.3
+:Version: 1.0.4
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.0.2
+:Version: 1.0.3
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.0.4
+:Version: 1.1.0
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -70,12 +70,16 @@ class clusterMAF():
 
     def __init__(self, theta, **kwargs):
 
+        # Unpack kwargs
         self.number_networks = kwargs.pop('number_networks', 6)
         self.learning_rate = kwargs.pop('learning_rate', 1e-3)
         self.hidden_layers = kwargs.pop('hidden_layers', [50, 50])
         self.cluster_labels = kwargs.pop('cluster_labels', None)
         self.cluster_number = kwargs.pop('cluster_number', None)
         self.parameters = kwargs.pop('parameters', None)
+
+        # Avoid unintended side effects by copying theta
+        theta = theta.copy()
 
         if isinstance(theta, 
                       (anesthetic.samples.NestedSamples, 
@@ -94,7 +98,7 @@ class clusterMAF():
             weights = kwargs.pop('weights', np.ones(len(theta)))
 
         self.theta = theta
-        self.sample_weights = weights
+        self.sample_weights = weights.copy()
 
         # needed for marginal stats
         self.n = np.sum(self.sample_weights)**2 / \
@@ -105,6 +109,10 @@ class clusterMAF():
         b = ((self.n-2)*theta_min-theta_max)/(self.n-3)
         self.theta_min = kwargs.pop('theta_min', b)
         self.theta_max = kwargs.pop('theta_max', a)
+
+        # Avoid unintended side effects by copying theta_min and theta_max
+        self.theta_min = self.theta_min.copy()
+        self.theta_max = self.theta_max.copy()
 
         # Convert min and max to float 32
         self.theta_min = tf.cast(self.theta_min, tf.float32)

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -110,19 +110,11 @@ class clusterMAF():
         self.theta_min = kwargs.pop('theta_min', b)
         self.theta_max = kwargs.pop('theta_max', a)
 
-        # Avoid unintended side effects by copying theta_min and theta_max
-        if isinstance(self.theta_min, tf.Tensor):
-            self.theta_min = self.theta_min.clone()
-        else:
-            self.theta_min = self.theta_min.copy()
-        if isinstance(self.theta_max, tf.Tensor):
-            self.theta_max = self.theta_max.clone()
-        else:
-            self.theta_max = self.theta_max.copy()
-
-        # Convert min and max to float 32
-        self.theta_min = tf.cast(self.theta_min, tf.float32)
-        self.theta_max = tf.cast(self.theta_max, tf.float32)
+        # Convert min and max to float 32 if needed
+        if not isinstance(self.theta_min, tf.Tensor):
+            self.theta_min = tf.convert_to_tensor(self.theta_min.copy(), dtype=tf.float32)
+        if not isinstance(self.theta_max, tf.Tensor):
+            self.theta_max = tf.convert_to_tensor(self.theta_max.copy(), dtype=tf.float32)
 
         if type(self.number_networks) is not int:
             raise TypeError("'number_networks' must be an integer.")

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -103,8 +103,12 @@ class clusterMAF():
         theta_min = np.min(self.theta, axis=0)
         a = ((self.n-2)*theta_max-theta_min)/(self.n-3)
         b = ((self.n-2)*theta_min-theta_max)/(self.n-3)
-        self.theta_min = b
-        self.theta_max = a
+        self.theta_min = kwargs.pop('theta_min', b)
+        self.theta_max = kwargs.pop('theta_max', a)
+
+        # Convert min and max to float 32
+        self.theta_min = tf.cast(self.theta_min, tf.float32)
+        self.theta_max = tf.cast(self.theta_max, tf.float32)
 
         if type(self.number_networks) is not int:
             raise TypeError("'number_networks' must be an integer.")
@@ -274,7 +278,7 @@ class clusterMAF():
         # nan repalacement with 0 difficult in tensorflow
         logprob = []
         for flow in self.flow:
-            probs = flow.log_prob(params).numpy()
+            probs = flow.log_prob(params).numpy() - np.log(self.cluster_number)
             logprob.append(probs)
         logprob = np.array(logprob)
         logprob = logsumexp(logprob, axis=0)

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -111,8 +111,14 @@ class clusterMAF():
         self.theta_max = kwargs.pop('theta_max', a)
 
         # Avoid unintended side effects by copying theta_min and theta_max
-        self.theta_min = self.theta_min.copy()
-        self.theta_max = self.theta_max.copy()
+        if isinstance(self.theta_min, tf.Tensor):
+            self.theta_min = self.theta_min.clone()
+        else:
+            self.theta_min = self.theta_min.copy()
+        if isinstance(self.theta_max, tf.Tensor):
+            self.theta_max = self.theta_max.clone()
+        else:
+            self.theta_max = self.theta_max.copy()
 
         # Convert min and max to float 32
         self.theta_min = tf.cast(self.theta_min, tf.float32)

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -278,7 +278,6 @@ class clusterMAF():
                     probs[j] = np.log(1e-300)
             logprob.append(probs)
         logprob = np.array(logprob)
-        print(logprob.shape)
         logprob = logsumexp(logprob, axis=0)
 
         return logprob

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -278,7 +278,9 @@ class clusterMAF():
         # nan repalacement with 0 difficult in tensorflow
         logprob = []
         for flow in self.flow:
-            probs = flow.log_prob(params).numpy() - np.log(self.cluster_number)
+            probs = (flow.log_prob(
+                tf.convert_to_tensor(params, dtype=tf.float32)).numpy() -
+                     np.log(self.cluster_number))
             logprob.append(probs)
         logprob = np.array(logprob)
         logprob = logsumexp(logprob, axis=0)

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -154,14 +154,14 @@ class clusterMAF():
             ks = np.arange(2, 21)
             losses = []
             for k in ks:
-                kmeans = KMeans(k, random_state=0)
+                kmeans = KMeans(k, random_state=0, n_init='auto')
                 labels = kmeans.fit(self.theta).predict(self.theta)
                 losses.append(-silhouette_score(self.theta, labels))
             losses = np.array(losses)
             minimum_index = np.argmin(losses)
             self.cluster_number = ks[minimum_index]
 
-            kmeans = KMeans(self.cluster_number, random_state=0)
+            kmeans = KMeans(self.cluster_number, random_state=0, n_init='auto')
             self.cluster_labels = kmeans.fit(self.theta).predict(self.theta)
 
         if self.cluster_number == 20:
@@ -185,7 +185,7 @@ class clusterMAF():
                           "Reducing the number of clusters by 1.")
             minimum_index -= 1
             self.cluster_number = ks[minimum_index]
-            kmeans = KMeans(self.cluster_number, random_state=0)
+            kmeans = KMeans(self.cluster_number, random_state=0, n_init='auto')
             self.cluster_labels = kmeans.fit(self.theta).predict(self.theta)
             self.cluster_count = np.bincount(self.cluster_labels)
             if self.cluster_number == 2:

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -150,7 +150,7 @@ class MAF():
             for i in range(len(self.hidden_layers)):
                 if type(self.hidden_layers[i]) is not int:
                     raise TypeError(
-                        "One or more valus in 'hidden_layers'" +
+                        "One or more values in 'hidden_layers'" +
                         "is not an integer.")
 
         self.optimizer = tf.keras.optimizers.legacy.Adam(

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -86,6 +86,9 @@ class MAF():
         self.hidden_layers = kwargs.pop('hidden_layers', [50, 50])
         self.parameters = kwargs.pop('parameters', None)
 
+        # Avoids unintended side effects outside of the class
+        theta = theta.copy()
+
         if isinstance(theta, 
                       (anesthetic.samples.NestedSamples, 
                        anesthetic.samples.MCMCSamples)):
@@ -103,7 +106,7 @@ class MAF():
             weights = kwargs.pop('weights', np.ones(len(theta)))
 
         self.theta = tf.convert_to_tensor(theta, dtype=tf.float32)
-        self.sample_weights = tf.convert_to_tensor(weights, dtype=tf.float32)
+        self.sample_weights = tf.convert_to_tensor(weights.copy(), dtype=tf.float32)
 
         mask = np.isfinite(theta).all(axis=-1)
         self.theta = tf.boolean_mask(self.theta, mask, axis=0)
@@ -120,6 +123,10 @@ class MAF():
         b = ((self.n-2)*theta_min-theta_max)/(self.n-3)
         self.theta_min = kwargs.pop('theta_min', b)
         self.theta_max = kwargs.pop('theta_max', a)
+
+        # Avoids unintended side effects outside of the class
+        self.theta_min = self.theta_min.copy()
+        self.theta_max = self.theta_max.copy()
 
         # Convert to tensors if not already
         if not isinstance(self.theta_min, tf.Tensor):

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -124,21 +124,11 @@ class MAF():
         self.theta_min = kwargs.pop('theta_min', b)
         self.theta_max = kwargs.pop('theta_max', a)
 
-        # Avoids unintended side effects outside the class
-        if isinstance(self.theta_min, tf.Tensor):
-            self.theta_min = self.theta_min.clone()
-        else:
-            self.theta_min = self.theta_min.copy()
-        if isinstance(self.theta_max, tf.Tensor):
-            self.theta_max = self.theta_max.clone()
-        else:
-            self.theta_max = self.theta_max.copy()
-
         # Convert to tensors if not already
         if not isinstance(self.theta_min, tf.Tensor):
-            self.theta_min = tf.convert_to_tensor(self.theta_min, dtype=tf.float32)
+            self.theta_min = tf.convert_to_tensor(self.theta_min.copy(), dtype=tf.float32)
         if not isinstance(self.theta_max, tf.Tensor):
-            self.theta_max = tf.convert_to_tensor(self.theta_max, dtype=tf.float32)
+            self.theta_max = tf.convert_to_tensor(self.theta_max.copy(), dtype=tf.float32)
 
         # Discard samples outside the prior range, provide a warning if any
         # are discarded

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -316,7 +316,9 @@ class MAF():
                 | Samples on the uniform hypercube.
 
         """
-        u = tf.cast(u, dtype=tf.float32)
+
+        if u.dtype != tf.float32:
+            u = tf.cast(u, tf.float32)
 
         x = _forward_transform(u)
         x = self.bij(x)

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -86,7 +86,7 @@ class MAF():
         self.hidden_layers = kwargs.pop('hidden_layers', [50, 50])
         self.parameters = kwargs.pop('parameters', None)
 
-        # Avoids unintended side effects outside of the class
+        # Avoids unintended side effects outside the class
         theta = theta.copy()
 
         if isinstance(theta, 
@@ -124,9 +124,15 @@ class MAF():
         self.theta_min = kwargs.pop('theta_min', b)
         self.theta_max = kwargs.pop('theta_max', a)
 
-        # Avoids unintended side effects outside of the class
-        self.theta_min = self.theta_min.copy()
-        self.theta_max = self.theta_max.copy()
+        # Avoids unintended side effects outside the class
+        if isinstance(self.theta_min, tf.Tensor):
+            self.theta_min = self.theta_min.clone()
+        else:
+            self.theta_min = self.theta_min.copy()
+        if isinstance(self.theta_max, tf.Tensor):
+            self.theta_max = self.theta_max.clone()
+        else:
+            self.theta_max = self.theta_max.copy()
 
         # Convert to tensors if not already
         if not isinstance(self.theta_min, tf.Tensor):

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -127,6 +127,15 @@ class MAF():
         if not isinstance(self.theta_max, tf.Tensor):
             self.theta_max = tf.convert_to_tensor(self.theta_max, dtype=tf.float32)
 
+        # Discard samples outside the prior range, provide a warning if any
+        # are discarded
+        mask = (self.theta >= self.theta_min) & (self.theta <= self.theta_max)
+        if not mask.all():
+            warnings.warn('Some samples are outside the user specified prior range '
+                          'and will be discarded!')
+            self.theta = tf.boolean_mask(self.theta, mask, axis=0)
+            self.sample_weights = tf.boolean_mask(self.sample_weights, mask, axis=0)
+
         if type(self.number_networks) is not int:
             raise TypeError("'number_networks' must be an integer.")
         if not isinstance(self.learning_rate,

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -132,7 +132,8 @@ class MAF():
         mask = (self.theta >= self.theta_min) & (self.theta <= self.theta_max)
         if not mask.all():
             warnings.warn('Some samples are outside the user specified prior range '
-                          'and will be discarded!')
+                          'and will be discarded! The specified range is likely smaller ' 
+                          'than the range covered by the samples.')
             self.theta = tf.boolean_mask(self.theta, mask, axis=0)
             self.sample_weights = tf.boolean_mask(self.sample_weights, mask, axis=0)
 

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -137,7 +137,7 @@ class MAF():
         # Discard samples outside the prior range, provide a warning if any
         # are discarded
         mask = (self.theta >= self.theta_min) & (self.theta <= self.theta_max)
-        if not mask.all():
+        if not tf.math.reduce_all(mask):
             warnings.warn('Some samples are outside the user specified prior range '
                           'and will be discarded! The specified range is likely smaller ' 
                           'than the range covered by the samples.')

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -10,7 +10,7 @@ import pickle
 import anesthetic
 
 
-class MAF():
+class MAF:
 
     r"""
 
@@ -87,7 +87,10 @@ class MAF():
         self.parameters = kwargs.pop('parameters', None)
 
         # Avoids unintended side effects outside the class
-        theta = theta.copy()
+        if not isinstance(theta, tf.Tensor):
+            theta = theta.copy()
+        else:
+            theta = tf.identity(theta)
 
         if isinstance(theta, 
                       (anesthetic.samples.NestedSamples, 

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -109,7 +109,13 @@ class MAF:
             weights = kwargs.pop('weights', np.ones(len(theta)))
 
         self.theta = tf.convert_to_tensor(theta, dtype=tf.float32)
-        self.sample_weights = tf.convert_to_tensor(weights.copy(), dtype=tf.float32)
+        if not isinstance(weights, tf.Tensor):
+            weights = tf.convert_to_tensor(weights.copy(), dtype=tf.float32)
+        else:
+            weights = tf.identity(weights)
+        if weights.dtype != tf.float32:
+            weights = tf.cast(weights, tf.float32)
+        self.sample_weights = weights
 
         mask = np.isfinite(theta).all(axis=-1)
         self.theta = tf.boolean_mask(self.theta, mask, axis=0)

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -350,7 +350,7 @@ class MAF():
         """
 
         # Enforce float32 dtype
-        params = tf.convert_to_tensor(params, dtype=tf.float32)
+        params = tf.cast(params, tf.float32)
 
         def calc_log_prob(mins, maxs, maf):
 

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -349,6 +349,9 @@ class MAF():
 
         """
 
+        # Enforce float32 dtype
+        params = tf.convert_to_tensor(params, dtype=tf.float32)
+
         def calc_log_prob(mins, maxs, maf):
 
             """Function to calculate log-probability for a given MAF."""

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -120,8 +120,12 @@ class MAF():
         b = ((self.n-2)*theta_min-theta_max)/(self.n-3)
         self.theta_min = kwargs.pop('theta_min', b)
         self.theta_max = kwargs.pop('theta_max', a)
-        self.theta_min = tf.convert_to_tensor(theta_min, dtype=tf.float32)
-        self.theta_max = tf.convert_to_tensor(theta_max, dtype=tf.float32)
+
+        # Convert to tensors if not already
+        if not isinstance(self.theta_min, tf.Tensor):
+            self.theta_min = tf.convert_to_tensor(self.theta_min, dtype=tf.float32)
+        if not isinstance(self.theta_max, tf.Tensor):
+            self.theta_max = tf.convert_to_tensor(self.theta_max, dtype=tf.float32)
 
         if type(self.number_networks) is not int:
             raise TypeError("'number_networks' must be an integer.")
@@ -331,7 +335,7 @@ class MAF():
         u = tf.random.uniform((length, len(self.theta_min)))
         return self(u)
 
-    @tf.function(jit_compile=True)
+    @tf.function(jit_compile=True, reduce_retracing=True)
     def log_prob(self, params):
 
         """
@@ -352,7 +356,8 @@ class MAF():
         """
 
         # Enforce float32 dtype
-        params = tf.cast(params, tf.float32)
+        if params.dtype != tf.float32:
+            params = tf.cast(params, tf.float32)
 
         def calc_log_prob(mins, maxs, maf):
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='1.0.2',
+    version='1.0.3',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='1.0.1',
+    version='1.0.2',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='1.0.3',
+    version='1.0.4',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='1.0.4',
+    version='1.1.0',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',


### PR DESCRIPTION
As outlined in more detail in issue #38 the flows in `clusterMAF` were incorrectly weighted in `__call__` and not weighted in `log_prob`. These led to incorrect sampling distributions and erroneous $D_{\rm KL}$ values respectively. This PR fixes #38 by now weighting the flows in both of these contexts in proportion to the sample weights in the corresponding clusters. 

Additional minor changes:

- Minor version bump
- Casting of some inputs to tf.float32 when required to avoid type comparison errors
- Set n_init to 10 explicitly to stop deprecation warning from scikit
- Copying of some inputs to avoid unintended side effects
- Check no samples are outside prior ranges if set, discard and warn if any are
- Typo fixes in comments 