### PR TITLE
Kde weights fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.1.0
+:Version: 1.1.1
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/margarine/kde.py
+++ b/margarine/kde.py
@@ -134,7 +134,7 @@ class KDE(object):
         weights_phi /= weights_phi.sum()
 
         self.kde = gaussian_kde(
-            phi.T, weights=self.sample_weights, bw_method=self.bw_method)
+            phi.T, weights=weights_phi, bw_method=self.bw_method)
 
         return self.kde
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='margarine',
-    version='1.1.0',
+    version='1.1.1',
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',


### PR DESCRIPTION
In the `generate_kde()` function we mask the data and the weights just in case the normalisation in `_forward_transform()` has introduced any nans to the array. However, in the

```python
self.kde = gaussian_kde(
            phi.T, weights=self.sample_weights, bw_method=self.bw_method)
```
but `self.sample_weights` is not the masked weights and the line should be

```python
self.kde = gaussian_kde(
            phi.T, weights=weights_phi, bw_method=self.bw_method)
```


