### PR TITLE
Add Version Increment Check Workflow

### DIFF
--- a/.github/workflows/version_checks.yaml
+++ b/.github/workflows/version_checks.yaml
@@ -1,0 +1,18 @@
+name: Version_Checks
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  version-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Upgrade pip and install linters
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install packaging
+      - name: Check version number
+        run: python ./bin/check_version.py

--- a/bin/check_version.py
+++ b/bin/check_version.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+"""Check Version.
+
+Verify version has been incremented.
+
+Based on check_version.py from the anesthetic GitHub repository:
+https://github.com/handley-lab/anesthetic
+"""
+
+
+import sys
+import subprocess
+from packaging import version
+
+
+# Filestructure
+readme_file = "README.rst"
+
+
+# Utility functions
+def run_on_commandline(*args):
+    """Run the given arguments as a command on the command line."""
+    return subprocess.run(args, text=True, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE).stdout
+
+
+def unit_incremented(version_a: str, version_b: str) -> bool:
+    """Check if version_a is one version larger than version_b.
+
+    Parameters
+    ----------
+    version_a: str
+        New version, version number
+    version_b: str
+        Old version, version number
+
+    Returns
+    -------
+    unit_incremented: bool
+        Whether, version number has been unit incremented
+    """
+    # Convert to version objects
+    version_a = version.parse(version_a)
+    version_b = version.parse(version_b)
+
+    # Check increment for pre-release versions
+    if version_a.pre is not None and version_b.pre is not None:
+        # Matching pre-release levels
+        if version_a.pre[0] == version_b.pre[0]:
+            return ((version_a.pre[1] == (int(version_b.pre[1]) + 1)) and
+                    (version_a.base_version == version_b.base_version))
+        # Differing pre-release levels
+        else:
+            return (version_a.pre[1] == 0 and
+                    version_a.pre[0] > version_b.pre[0] and
+                    version_a.base_version == version_b.base_version)
+
+    # New pre-release level
+    elif version_a.pre is not None:
+        return (version_a.base_version > version_b.base_version and
+                version_a.pre[1] == 0)
+
+    # Full release
+    elif version_b.pre is not None:
+        return version_a.base_version == version_b.base_version
+
+    # Standard version major, minor and micro increments
+    else:
+        return (version_a.micro == version_b.micro + 1 and
+                version_a.minor == version_b.minor and
+                version_a.major == version_b.major or
+                version_a.micro == 0 and
+                version_a.minor == version_b.minor + 1 and
+                version_a.major == version_b.major or
+                version_a.micro == 0 and
+                version_a.minor == 0 and
+                version_a.major == version_b.major+1)
+
+def get_current_version() -> str:
+    """Get current version of package from README.rst"""
+    current_version = run_on_commandline("grep", ":Version:", readme_file)
+    current_version = current_version.split(":")[-1].strip()
+    return current_version
+
+def main():
+    """Check version is consistent and incremented correctly."""
+    # Get current version from readme
+    current_version = get_current_version()
+
+    # Get previous version from main branch of code
+    run_on_commandline("git", "fetch", "origin", "master")
+    readme_contents = run_on_commandline("git", "show",
+                                         "remotes/origin/master:" +
+                                         readme_file)
+
+    previous_version = None
+    for line in readme_contents.splitlines():
+        if ":Version:" in line:
+            previous_version = line.split(":")[-1].strip()
+            break
+
+    if previous_version is None:
+        raise ValueError("Could not find version in README.rst on master branch")
+
+    # Check versions have been incremented
+    if not unit_incremented(current_version, previous_version):
+        sys.stderr.write(("Version must be incremented by one:\n"
+                          "HEAD:   {},\n"
+                          "master: {}.\n").format(current_version,
+                                                  previous_version))
+        sys.exit(1)
+
+    # No issues found, exit happily :)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/get_version.py
+++ b/bin/get_version.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Get Version.
+
+This script will print the version of the current project.
+"""
+
+
+import sys
+from check_version import run_on_commandline, readme_file, get_current_version
+
+
+def main():
+    """Print the current version of the project."""
+    # Get current version from readme
+    current_version = get_current_version()
+
+    # Print current version
+    sys.stdout.write(f"{current_version}")
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,18 @@ def readme(short=False):
         else:
             return f.read()
 
+def get_version_from_readme() -> str:
+    """Get current version of package from README.rst"""
+    readme_text = readme()
+    for line in readme_text.splitlines():
+        if ":Version:" in line:
+            current_version = line.split(":")[-1].strip()
+            return current_version
+    raise ValueError("Could not find version in README.rst")
+
 setup(
     name='margarine',
-    version='1.2.3',
+    version=get_version_from_readme(),
     description='margarine: Posterior Sampling and Marginal Bayesian Statistics',
     long_description=readme(),
     author='Harry T. J. Bevins',


### PR DESCRIPTION
Adds a GitHub workflow that automatically checks the version number has been incremented in a PR. It fails if the version has not been incremented appropriately. This PR also removes the duplicate specifications of version numbers by having `setup.py` read the version number from `README.rst` to avoid self-inconsistency issues.

This feature was requested in #52 .

**Note:** This PR should intentionally fail the version increment check initially as part of testing. 