### PR TITLE
make full use of autodoc such that cross referencing can find all targets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.2.3
+:Version: 1.2.5
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,9 +3,9 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = .
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = source
 BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,7 @@ release = get_version()
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
@@ -63,12 +64,16 @@ extensions = [
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc='index'
+master_doc = 'index'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = []
+
+autosummary_generate = True
+
+numpydoc_class_members_toctree = False
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -4,27 +4,18 @@
 margarine Functions
 --------------------
 
-margarine.maf.MAF()
-~~~~~~~~~~~~~~~~~~~~
+.. automodule:: margarine.maf
+    :members:
+    :special-members: __call__
 
-.. automodule:: margarine.maf.MAF()
-    :members: gen_mades, train, _train_step, _test_step, _training, __call__, sample, log_prob, log_like, save, load
+.. automodule:: margarine.kde
+    :members:
+    :special-members: __call__
 
-margarine.kde.KDE()
-~~~~~~~~~~~~~~~~~~~~
+.. automodule:: margarine.clustered
+    :members:
+    :special-members: __call__
 
-.. automodule:: margarine.kde.KDE()
-    :members: generate_kde, __call__, sample, log_prob, log_like, save, load
-
-margarine.clustered.clusterMAF()
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: margarine.clustered.clusterMAF()
-    :members: train, __call__, sample, log_prob, log_like, save, load
-
-margarine.marginal_stats.calculate()
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: margarine.marginal_stats.calculate
-    :members: statistics
+.. automodule:: margarine.marginal_stats
+    :members:
 

--- a/margarine/kde.py
+++ b/margarine/kde.py
@@ -45,6 +45,7 @@ class KDE(object):
             | A list of the relevant parameters to train on. Only needed
                 if theta is an anestehetic samples object. If not provided,
                 all parameters will be used.
+
     **Attributes:**
 
     A list of some key attributes accessible to the user.

--- a/margarine/marginal_stats.py
+++ b/margarine/marginal_stats.py
@@ -212,8 +212,8 @@ class calculate(object):
                   The definition of zero for the loglikelihood function.
 
         returns:
-        stats: **dict**
-            | Dictionary containing useful statistics
+            stats: **dict**
+                | Dictionary containing useful statistics
 
         """
         xs = np.empty((sample_size, self.de.theta.shape[-1]))


### PR DESCRIPTION
This PR is motivated by a docs related issue that came up in handley-lab/anesthetic#353. 

Currently the docs are generated in a way that does not allow cross-referencing of all modules and its members. This PR should (hopefully) remedy that. This comes with the added benefit of simplifying the docs source code, leveraging more of the autodoc power.