### PR TITLE
Fix dostring formatting of activation func

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.2.5
+:Version: 1.2.6
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/margarine/clustered.py
+++ b/margarine/clustered.py
@@ -52,8 +52,8 @@ class clusterMAF():
         
         activation_func: **string / default = 'tanh'**
             | The choice of activation function. It must be an activation
-            function keyword recognisable by TensorFlow. The default is
-            'tanh', the hyperbolic tangent activation function.
+                function keyword recognisable by TensorFlow. The default is
+                'tanh', the hyperbolic tangent activation function.
 
         cluster_labels: **list / default = None**
             | If clustering has been performed externally to margarine you can

--- a/margarine/maf.py
+++ b/margarine/maf.py
@@ -50,8 +50,8 @@ class MAF:
 
         activation_func: **string / default = 'tanh'**
             | The choice of activation function. It must be an activation
-            function keyword recognisable by TensorFlow. The default is
-            'tanh', the hyperbolic tangent activation function.
+                function keyword recognisable by TensorFlow. The default is
+                'tanh', the hyperbolic tangent activation function.
 
         theta_max: **numpy array**
             | The true upper limits of the priors used to generate the samples


### PR DESCRIPTION
Incorrect indentation in dostrings for the `activation_func` parameter fixed.