### PR TITLE
Fix `readthedocs.yml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__
+margarine.egg-info/
+build
+_build

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,15 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: html
   configuration: docs/source/conf.py
   fail_on_warning: false
 
@@ -12,7 +19,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.2.5
+:Version: 1.2.7
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 


### PR DESCRIPTION
The docs on readthedocs are currently failing. I suspect this has to do with the missing `build` block specifying what OS to use. Let's see whether this fixes it.

@htjb, could you tell readthedocs to build this branch, please? (alternatively give me the power and I'll fiddle around)