### PR TITLE
Temporary tensorflow fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :margarine: Marginal Bayesian Statistics
 :Authors: Harry T.J. Bevins
-:Version: 1.2.7
+:Version: 1.2.8
 :Homepage:  https://github.com/htjb/margarine
 :Documentation: https://margarine.readthedocs.io/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
-tensorflow-macos; sys_platform == 'darwin'
-tensorflow; sys_platform != 'darwin'
+tensorflow-macos<2.14.0; sys_platform == 'darwin'
+tensorflow<2.14.0; sys_platform != 'darwin'
 tensorflow_probability
 anesthetic
 scipy


### PR DESCRIPTION
Temporary partial fix for #37. Limiting tensor flow version to <2.14.0. Need to make it work with the latest version in long run.